### PR TITLE
Fix crash to menu bug

### DIFF
--- a/scripts/core.lua
+++ b/scripts/core.lua
@@ -233,7 +233,7 @@ function get_blueprint_counts(entities, tiles)
             if item_requests and next(item_requests) then
                 for _, item_request in pairs(item_requests) do
                     local name = item_request.id.name --[[@as string]]
-                    local quality = item_request.id.quality --[[@as string]]
+                    local quality = item_request.id.quality or base_quality--[[@as string]]
                     local name_and_quality = name .. "+" .. quality
 
                     requests[name_and_quality] = requests[name_and_quality] or make_empty_request(name, quality)
@@ -367,6 +367,7 @@ end
 function update_logistics_info(player_index)
     local playerdata = get_make_playerdata(player_index)
     local requests = playerdata.job.requests
+    local base_quality = get_base_quality()
 
     -- Get player character
     local character = playerdata.luaplayer.character
@@ -378,7 +379,8 @@ function update_logistics_info(player_index)
     local logistic_requests = {}
     if logistic_point and logistic_point.filters then
         for _, slot in pairs(logistic_point.filters) do
-            local name_and_quality = slot.name .. "+" .. slot.quality
+            local entity_quality = slot.quality or base_quality
+            local name_and_quality = slot.name .. "+" .. entity_quality
             if requests[name_and_quality] then
                 requests[name_and_quality].requested = slot.count
                 logistic_requests[name_and_quality] = true


### PR DESCRIPTION
This fixes the errors [reported here](https://mods.factorio.com/mod/ghost-counter/discussion/6736c0b8d1cdff2506cf4028) and in issues #4,  #5 , and #7 

For reference, here is an example of the error.
<img width="697" height="447" alt="Screenshot 2025-07-22 205539" src="https://github.com/user-attachments/assets/7bf19568-300c-4d8d-80d4-4138e7f24fca" />

This seems to occur when making a selection with pre-defined logistics trash requests like those highlighted here:
<img width="461" height="104" alt="Screenshot 2025-07-23 003310" src="https://github.com/user-attachments/assets/bb1a0a18-7f81-4f77-89e7-b386c2cebecd" />

This PR addresses two possible places where concatenation can occur against a possibly nill value.  While this fix may result in certain items either not being requested (or perhaps the wrong quality being requested?), it does prevent the crash to the main menu.  